### PR TITLE
Delay generating sub for `tr`

### DIFF
--- a/git-foresta
+++ b/git-foresta
@@ -121,7 +121,7 @@ my $Graph_symbol_merge    = '◎';
 my $Graph_symbol_overpass = '═';
 my $Graph_symbol_root     = '■';
 my $Graph_symbol_tip      = '○';
-my $Graph_symbol_tr       = trgen();
+my $Graph_symbol_tr;
 
 $SIG{'PIPE'} = 'DEFAULT'; # avoid broken pipe error
 
@@ -175,6 +175,7 @@ sub main
       exit;
     },
   );
+  $Graph_symbol_tr = trgen();
   ++$Subvine_depth;
   if (substr($Pretty_fmt, 0, 7) ne "format:") {
     die "If you use --pretty, it must be in the form of --pretty=format:";

--- a/script/git-foresta
+++ b/script/git-foresta
@@ -67,7 +67,7 @@ my $Graph_symbol_merge    = '◎';
 my $Graph_symbol_overpass = '═';
 my $Graph_symbol_root     = '■';
 my $Graph_symbol_tip      = '○';
-my $Graph_symbol_tr       = trgen();
+my $Graph_symbol_tr;
 
 $SIG{'PIPE'} = 'DEFAULT'; # avoid broken pipe error
 
@@ -121,6 +121,7 @@ sub main
       exit;
     },
   );
+  $Graph_symbol_tr = trgen();
   ++$Subvine_depth;
   if (substr($Pretty_fmt, 0, 7) ne "format:") {
     die "If you use --pretty, it must be in the form of --pretty=format:";


### PR DESCRIPTION
After this commit e1715ac, `--graph-symbol-xxx` options makes no sense. This PR fixes it. 

`trgen()` is created to generate the function beforehand so that it decreases `tr`ing overhead. But the phase is too early, and it cannot detect `--graph-symbol-xxx` options users specify in command execution.